### PR TITLE
add: 업로드 파일 크기 설정 기능 추가 241202

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,7 @@ mybatis.mapper-locations=classpath:mybatis/mappers/**/*.xml
 spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
 spring.thymeleaf.cache=false
+
+# 업로드 파일 크기 설정
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=50MB


### PR DESCRIPTION
제목:  application.properties 기능 추가

## 🔘Part
- application.properties 

## 🔎 기능 간략히

- 업로드 파일의 크기를 설정

## 🔎 작업 상세 내용

- 업로드 파일의 크기를 설정

## 이미지 첨부 (작업 내용)
![image](https://github.com/user-attachments/assets/a531b2ce-364f-4bf9-89cd-9363f2fa4ec3)


<br/>

## 🔧 버그 리포트 간략히  (상세 내용은 isssues에 사진과 함께 첨부해주세요.)

- 

## 🔧 앞으로의 과제

- managerdto와 employeedto 사용해서 사원 id에 task 저장하도록 하기
- html thymeleaf로 설정 바꾸기 
- 팀원 전원 완료하면 모든 파일 병합하고 오류 검토하기

  <br/>

## ➕ 이슈 링크

<br/>

