### PR TITLE
Jisoo: pagehelper, 직원 정보 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '2.6.3'
 	// Validation 라이브러리 추가_원진호_1206 추가
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// 페이지헬퍼 추가 - 심지수
+	implementation 'com.github.pagehelper:pagehelper-spring-boot-starter:1.4.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cis/member/repository/IF_MemberDao.java
+++ b/src/main/java/com/cis/member/repository/IF_MemberDao.java
@@ -5,6 +5,7 @@ import com.cis.member.dto.ManagerDTO;
 import com.cis.member.dto.ManagerEmployeeDTO;
 import com.cis.member.dto.PageDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -86,6 +87,12 @@ public interface IF_MemberDao {
 
     public int count_employee_need_complete() throws Exception;
 
+    // 부서, 직급, 이름으로 사원 정보 조회 -- JISOO
+    ManagerEmployeeDTO findEmployeeByDeptRankName(@Param("emp_dept") String emp_dept,
+                                                  @Param("emp_rank") String emp_rank,
+                                                  @Param("emp_name") String emp_name) throws Exception;
 
+    // emp_id로 직원 정보 조회 -- JISOO
+    ManagerEmployeeDTO findEmployeeById(@Param("emp_id") String emp_id) throws Exception;
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ spring.application.name=CIS_Final
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/CIS_FinalProject?autoReconnect=true
 spring.datasource.username=root
-spring.datasource.password=11111111
+spring.datasource.password=qazer1123!
 
 # MyBatis 설정
 mybatis.config-location=classpath:mybatis/mybatis-config.xml
@@ -36,3 +36,12 @@ spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.writetimeout=5000
 spring.auth-code-expiration-millis=1800000
+
+# Pagehelper 설정 심지수
+pagehelper.helper-dialect=mysql
+pagehelper.reasonable=true
+#mybatis:
+#configuration:
+#map-underscore-to-camel-case: true # 카멜 케이스 매핑 설정
+#default-fetch-size: 100 # 기본 fetch 크기
+#default-statement-timeout: 30 # 기본 타임아웃 (초)


### PR DESCRIPTION
제목: pagehelper, 직원 정보 조회 기능 추가

## 🔘Part

- 개인 업무 기능

  <br/>

## 🔎 기능 간략히

- pagehelper
- IF_MemberDao에 조회 기능 추가

## 🔎 작업 상세 내용

- pagehelper의 기본 설정 파일을 추가 하였음.
- 직원의 부서, 직급, 이름의 정보를 조회할 수 있는 기능을 추가하였음.

  <br/>

## 이미지 첨부 (작업 내용)
![image](https://github.com/user-attachments/assets/74996a4f-1bc7-4dbf-9857-ae6f410b2051)
![image](https://github.com/user-attachments/assets/a49f3032-bf03-4d9b-b066-02a12f0b50aa)
![image](https://github.com/user-attachments/assets/03c300ec-56ca-4e7e-a4df-6f34d417c9de)


<br/>

## 🔧 버그 리포트 간략히  (상세 내용은 isssues에 사진과 함께 첨부해주세요.)

- 

## 🔧 앞으로의 과제

- 리팩토링, 오류 개선
- 템플릿 변경

  <br/>

## ➕ 이슈 링크


<br/>

